### PR TITLE
Adding timing measures in setmodel and spawnmodel 

### DIFF
--- a/Source/UROSControl/Private/SrvCallbacks/SetModelPoseServer.cpp
+++ b/Source/UROSControl/Private/SrvCallbacks/SetModelPoseServer.cpp
@@ -30,7 +30,7 @@ TSharedPtr<FROSBridgeSrv::SrvResponse> FROSSetModelPoseServer::Callback(TSharedP
 	Params.Location = FConversions::ROSToU(SetModelPoseRequest->GetPose().GetPosition().GetVector());
 	Params.Rotator = FRotator(FConversions::ROSToU(SetModelPoseRequest->GetPose().GetOrientation().GetQuat()));
 
-
+	double start = FPlatformTime::Seconds();
 	//The rest has to be done in the game thread
 	FGraphEventRef Task = FFunctionGraphTask::CreateAndDispatchWhenReady([&]()
 	{
@@ -55,6 +55,9 @@ TSharedPtr<FROSBridgeSrv::SrvResponse> FROSSetModelPoseServer::Callback(TSharedP
 
 	//wait code above to complete
 	FTaskGraphInterface::Get().WaitUntilTaskCompletes(Task);
+	double end = FPlatformTime::Seconds();
+	UE_LOG(LogTemp, Display, TEXT("SetModelPose executed in %f seconds."), end-start);
+
 
 	return MakeShareable<FROSBridgeSrv::SrvResponse>
 		(new FROSSetModelPoseSrv::Response(ServiceSuccess));

--- a/Source/UROSControl/Private/SrvCallbacks/SpawnModelsServer.cpp
+++ b/Source/UROSControl/Private/SrvCallbacks/SpawnModelsServer.cpp
@@ -51,6 +51,7 @@ TSharedPtr<FROSBridgeSrv::SrvResponse> FROSSpawnModelServer::Callback(TSharedPtr
 
 	FString FinalActorName;
 	// Execute on game thread
+	double start = FPlatformTime::Seconds();
 	FGraphEventRef Task = FFunctionGraphTask::CreateAndDispatchWhenReady([&]()
 	{
 		ServiceSuccess = FAssetSpawner::SpawnAsset(World, Params, FinalActorName);
@@ -58,6 +59,8 @@ TSharedPtr<FROSBridgeSrv::SrvResponse> FROSSpawnModelServer::Callback(TSharedPtr
 
 	//wait code above to complete
 	FTaskGraphInterface::Get().WaitUntilTaskCompletes(Task);
+	double end = FPlatformTime::Seconds();
+	UE_LOG(LogTemp, Display, TEXT("SpawnModel executed in %f seconds."), end-start);
 
 	return MakeShareable<FROSBridgeSrv::SrvResponse>
 		(new FROSSpawnModelSrv::Response(Params.Id, FinalActorName, ServiceSuccess));


### PR DESCRIPTION
This is something that Jose and me had sometimes trouble with:
Some service requests are getting into the callback, but the response isn't properly sent back to the service client which causes the caller to hang. Interestingly, adding the elapsed time measurement helps to reduce these timeout issues a lot + adds a bit of debugging help to have more control over the process.