### PR TITLE
adaption for rs_bs and UE4.22.3

### DIFF
--- a/Source/UROSControl/Private/UROSControl.cpp
+++ b/Source/UROSControl/Private/UROSControl.cpp
@@ -17,4 +17,4 @@ void FUROSControl::ShutdownModule()
 
 #undef LOCTEXT_NAMESPACE
 
-IMPLEMENT_MODULE(FUROSControl, UROSWorldControl)
+IMPLEMENT_MODULE(FUROSControl, UROSControl)

--- a/Source/UROSControl/Public/UROSCallbackRegisterBase.h
+++ b/Source/UROSControl/Public/UROSCallbackRegisterBase.h
@@ -1,0 +1,41 @@
+// Copyright 2017-2019, Institute for Artificial Intelligence - University of Bremen
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "ROSBridgeSrvServer.h"
+#include "ROSBridgePublisher.h"
+#include "ROSBridgeSubscriber.h"
+#include "UROSCallbackRegisterBase.generated.h"
+
+/**
+ * This class is essentially an Interface. It is not meant to be instantiated.
+ * An actuall interface could not be used, because Editor selection does not support
+ * arrays of an interfaces type.
+ */
+
+UCLASS(abstract)
+class UROSCONTROL_API UROSCallbackRegisterBase : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UROSCallbackRegisterBase(){}
+	~UROSCallbackRegisterBase() {}
+
+	/* 
+	 * After call to this function the Arrays are expected to be set up correctly.
+	 * If Namespace is not needed, just ignore it. It will always be provided.
+	 */
+	virtual void Register(FString DefaultNamespace)
+	{
+		UE_LOG(LogTemp, Error, TEXT("[%s]: This function schould be overriden by derived class. This class is meant to function like an Interface."), *FString(__func__));
+	};
+
+	TArray<TSharedPtr<FROSBridgeSrvServer>> ServicesToPublish;
+	TArray<TSharedPtr<FROSBridgePublisher>> PublisherToPublish;
+	TArray<TSharedPtr<FROSBridgeSubscriber>> SubscriberToPublish;
+
+
+};

--- a/Source/UROSControl/UROSControl.Build.cs
+++ b/Source/UROSControl/UROSControl.Build.cs
@@ -28,7 +28,6 @@ public class UROSControl : ModuleRules
 				"Core",
                 "UWorldControl",
 			    "UROSBridge",
-			    "UROSBridgeEd",
                 "UTags",
 				"UIds",
 				"UConversions",

--- a/Source/UWorldControl/UWorldControl.Build.cs
+++ b/Source/UWorldControl/UWorldControl.Build.cs
@@ -33,7 +33,6 @@ public class UWorldControl : ModuleRules
                 "Core",
                 "UTags",
                 "UIds",
-			    "UROSBridgeEd",
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);


### PR DESCRIPTION
UROSCallbackRegisterBase.h was in UROSBridgeED but that package is deprecated, therefor i added the header file here, since RWC-Manager depends on it.  

Working with: - UE 4.22
                       - Latest UROSBridge version

