### PR TITLE
Adding override name field

### DIFF
--- a/Source/UROSControl/Private/SrvCallbacks/SpawnModelsServer.cpp
+++ b/Source/UROSControl/Private/SrvCallbacks/SpawnModelsServer.cpp
@@ -45,6 +45,7 @@ TSharedPtr<FROSBridgeSrv::SrvResponse> FROSSpawnModelServer::Callback(TSharedPtr
 	Params.PhysicsProperties.Mass = SpawnMeshRequest->GetPhysicsProperties().GetMass();
 	Params.StartDir = SpawnMeshRequest->GetPath();
 	Params.ActorLabel = SpawnMeshRequest->GetActorLabel();
+	Params.OverrideName = SpawnMeshRequest->GetOverrideName();
 	Params.MaterialNames = SpawnMeshRequest->GetMaterialNames();
 	Params.MaterialPaths = SpawnMeshRequest->GetMaterialPaths();
 	Params.ParentId = SpawnMeshRequest->GetParentId();

--- a/Source/UROSControl/Public/world_control_msgs/srv/SpawnModel.h
+++ b/Source/UROSControl/Public/world_control_msgs/srv/SpawnModel.h
@@ -24,6 +24,7 @@ public:
 		TArray<world_control_msgs::Tag> Tags;
 		FString Path;
 		FString ActorLabel;
+		FString OverrideName;
 		world_control_msgs::PhysicsProperties PhysicsProperties;
 		TArray<FString> MaterialNames;
 		TArray<FString> MaterialPaths;
@@ -34,7 +35,7 @@ public:
 	public:
 		Request() {}
 
-		Request(FString InName, geometry_msgs::Pose InPose, FString InId, TArray<world_control_msgs::Tag> InTags, FString InPath, FString InActorLabel, world_control_msgs::PhysicsProperties InPhysicsProperties, TArray<FString> InMaterialNames, TArray<FString> InMaterialPaths, FString InParentId, bool bInSpawnCollisionCheck)
+		Request(FString InName, geometry_msgs::Pose InPose, FString InId, TArray<world_control_msgs::Tag> InTags, FString InPath, FString InActorLabel, FString InOverrideName, world_control_msgs::PhysicsProperties InPhysicsProperties, TArray<FString> InMaterialNames, TArray<FString> InMaterialPaths, FString InParentId, bool bInSpawnCollisionCheck)
 		{
 			Name = InName;
 			Pose = InPose;
@@ -42,6 +43,7 @@ public:
 			Tags = InTags;
 			Path = InPath;
 			ActorLabel = InActorLabel;
+			OverrideName = InOverrideName;
 			PhysicsProperties = InPhysicsProperties;
 			MaterialNames = InMaterialNames;
 			MaterialPaths = InMaterialPaths;
@@ -77,6 +79,11 @@ public:
 		FString GetActorLabel()
 		{
 			return ActorLabel;
+		}
+
+		FString GetOverrideName()
+		{
+			return OverrideName;
 		}
 
 		world_control_msgs::PhysicsProperties GetPhysicsProperties()
@@ -120,6 +127,7 @@ public:
 
 			Path = JsonObject->GetStringField("path");
 			ActorLabel = JsonObject->GetStringField("actor_label");
+			OverrideName = JsonObject->GetStringField("override_name");
 			PhysicsProperties.FromJson(JsonObject->GetObjectField("physics_properties"));
 			MaterialNames.Empty();
 			TArray<TSharedPtr<FJsonValue>> MaterialNamesPtrArray = JsonObject->GetArrayField(TEXT("material_names"));
@@ -156,6 +164,7 @@ public:
 				", tags size = " + FString::FromInt(Tags.Num()) +
 				", path = " + Path +
 				", actor_label = " + ActorLabel +
+				", override_name = " + OverrideName +
 				", physics_properties = " + PhysicsProperties.ToString() +
 				", material_names size = " + FString::FromInt(MaterialNames.Num()) +
 				", material_paths size = " + FString::FromInt(MaterialPaths.Num()) +
@@ -179,6 +188,7 @@ public:
 
 			Object->SetStringField(TEXT("path"), Path);
 			Object->SetStringField(TEXT("actor_label"), ActorLabel);
+			Object->SetStringField(TEXT("override_name"), OverrideName);
 			Object->SetObjectField(TEXT("physics_properties"), PhysicsProperties.ToJsonObject());
 			TArray<TSharedPtr<FJsonValue>> MaterialNamesPtrArray;
 			for (auto &Entry : MaterialNames)

--- a/Source/UWorldControl/Private/AssetSpawner.cpp
+++ b/Source/UWorldControl/Private/AssetSpawner.cpp
@@ -21,7 +21,6 @@ bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FS
 	}
 
 	FString Label = (Params.ActorLabel.IsEmpty() ? Params.Name : Params.ActorLabel);
-	UE_LOG(LogTemp, Error, TEXT("[%s]: Computed input actor label is \"%s\"."), *FString(__FUNCTION__), *Label);
 #if WITH_EDITOR
 	GEditor->BeginTransaction(FText::FromString(TEXT("Spawning: ")+ Label));
 	World->Modify();
@@ -33,7 +32,6 @@ bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FS
   // Set the ActorName explicitly if supplied for non-editor builds
   if( !Params.OverrideName.IsEmpty())
   {
-	  UE_LOG(LogTemp, Error, TEXT("[%s]: Setting Override name is %s"), *FString(__FUNCTION__), *Params.OverrideName);
     SpawnParams.Name = *Params.OverrideName;
   }
   #endif

--- a/Source/UWorldControl/Private/AssetSpawner.cpp
+++ b/Source/UWorldControl/Private/AssetSpawner.cpp
@@ -11,6 +11,8 @@
 
 bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FString &FinalActorName, FString &ErrType)
 {
+	UE_LOG(LogTemp, Error, TEXT("[%s]: Handling callback"), *FString(__FUNCTION__));
+
 	//Check if World is avialable
 	if (!World)
 	{
@@ -19,6 +21,7 @@ bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FS
 	}
 
 	FString Label = (Params.ActorLabel.IsEmpty() ? Params.Name : Params.ActorLabel);
+	UE_LOG(LogTemp, Error, TEXT("[%s]: Computed input actor label is \"%s\"."), *FString(__FUNCTION__), *Label);
 #if WITH_EDITOR
 	GEditor->BeginTransaction(FText::FromString(TEXT("Spawning: ")+ Label));
 	World->Modify();
@@ -26,6 +29,14 @@ bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FS
 
 	//Setup SpawnParameters
 	FActorSpawnParameters SpawnParams;
+  #if !WITH_EDITOR
+  // Set the ActorName explicitly if supplied for non-editor builds
+  if( !Params.OverrideName.IsEmpty())
+  {
+	  UE_LOG(LogTemp, Error, TEXT("[%s]: Setting Override name is %s"), *FString(__FUNCTION__), *Params.OverrideName);
+    SpawnParams.Name = *Params.OverrideName;
+  }
+  #endif
 
 	//Load Mesh and check if it succeded.
 	UStaticMesh* Mesh = FAssetModifier::LoadMesh(Params.Name, Params.StartDir);

--- a/Source/UWorldControl/Private/AssetSpawner.cpp
+++ b/Source/UWorldControl/Private/AssetSpawner.cpp
@@ -11,8 +11,6 @@
 
 bool FAssetSpawner::SpawnAsset(UWorld* World, const FSpawnAssetParams Params, FString &FinalActorName, FString &ErrType)
 {
-	UE_LOG(LogTemp, Error, TEXT("[%s]: Handling callback"), *FString(__FUNCTION__));
-
 	//Check if World is avialable
 	if (!World)
 	{

--- a/Source/UWorldControl/Public/AssetSpawner.h
+++ b/Source/UWorldControl/Public/AssetSpawner.h
@@ -40,6 +40,7 @@ public:
 		FPhysicsProperties PhysicsProperties;
 		FString StartDir;
 		FString ActorLabel;
+		FString OverrideName;
 		TArray<FString> MaterialNames;
 		TArray<FString> MaterialPaths;
 		FString ParentId;


### PR DESCRIPTION
In packaged/non-editor builds, there are no actor labels.
We want to have a reliable way to set a unique name on Actors to reference them properly even without UUtils IDs.
This PR adds this functionality. It depends on https://github.com/robcog-iai/unreal_ros_pkgs/pull/18